### PR TITLE
FIX: bad varargs

### DIFF
--- a/cpp_bridge/include/verilated_cov.h
+++ b/cpp_bridge/include/verilated_cov.h
@@ -65,10 +65,10 @@
 ///		VL_COVER_INSERT(&m_cases[i], "comment", "Coverage Case", "i", cvtToNumStr(i));
 ///	}
 
-#define VL_COVER_INSERT(countp,args...) \
+#define VL_COVER_INSERT(countp,...) \
     VL_IF_COVER(VerilatedCov::_inserti(countp);	\
 		VerilatedCov::_insertf(__FILE__,__LINE__);	\
-		VerilatedCov::_insertp("hier", name(), args))
+		VerilatedCov::_insertp("hier", name(), __VA_ARGS__))
 
 //=============================================================================
 /// Convert VL_COVER_INSERT value arguments to strings

--- a/cpp_bridge/include/verilated_vpi.cpp
+++ b/cpp_bridge/include/verilated_vpi.cpp
@@ -473,7 +473,7 @@ public:
         m_errorInfo.level = level;
         return this;
     }
-    void setMessage(std::string file, PLI_INT32 line, const std::string& message, ...) {
+    void setMessage(std::string file, PLI_INT32 line, const std::string message, ...) {
         static VL_THREAD_LOCAL std::string filehold;
         va_list args;
         va_start(args, message);


### PR DESCRIPTION
Eliminate errors in MSVC >2015 and modern c++ compilers